### PR TITLE
improved descriptions of url and releases fields

### DIFF
--- a/.standard-GEM.md
+++ b/.standard-GEM.md
@@ -37,7 +37,7 @@ The topic `standard-GEM` must be added. Other topics like `genome-scale-models`,
 Topics are not copied from `standard-GEM`, so they need to be added manually.
 
 - [ ] 🟨 Add a repository URL  
-The URL can be the _doi_.
+The URL can be the link to the paper, for example via an identifier system like the doi, EuropePMC or PubMed.
 
 
 Repository workflow

--- a/.standard-GEM.md
+++ b/.standard-GEM.md
@@ -37,7 +37,7 @@ The topic `standard-GEM` must be added. Other topics like `genome-scale-models`,
 Topics are not copied from `standard-GEM`, so they need to be added manually.
 
 - [ ] 🟨 Add a repository URL  
-The URL can be the link to the paper, for example via an identifier system like the doi, EuropePMC or PubMed.
+The URL can be the link to the publication/pre-print/website where the model is introduced, for example via an identifier system (doi/EuropePMC/PubMed).
 
 
 Repository workflow

--- a/.standard-GEM.md
+++ b/.standard-GEM.md
@@ -46,7 +46,7 @@ Repository workflow
 The GEM repository must have at least two branches: _master_ and _develop_.
 
 - [ ] 🟥 Releases  
-Releases must use the tag format `X.X.X` where X are numbers, according to [semantic versioning principles](https://semver.org/). The last field (“patch”) can also be used to indicate changes to the repository that do not actually change the GEM itself. The use of a `v` before the version number (`v1.0`) is [discouraged](https://semver.org/#is-v123-a-semantic-version).
+Releases must use the tag format `X.X.X` where X are numbers, according to [semantic versioning principles](https://semver.org/). The last field, also called “patch”, can also be used to indicate changes to the repository that do not actually change the GEM itself. The use of a `v` before the version number (`v1.0`) [is discouraged](https://semver.org/#is-v123-a-semantic-version). For more information about releases see the [documentation at GitHub](https://docs.github.com/en/github/administering-a-repository/managing-releases-in-a-repository).  
 
 - [ ] 🟨 Commits  
 Commit messages can follow the style of semantic commits.

--- a/.standard-GEM.md
+++ b/.standard-GEM.md
@@ -4,7 +4,7 @@ standard-GEM v0.4
 For details about the [aims](https://github.com/MetabolicAtlas/standard-GEM/wiki/Aims,-scope-and-terminology#aims), [scope](https://github.com/MetabolicAtlas/standard-GEM/wiki/Aims,-scope-and-terminology#scope), and [use case](https://github.com/MetabolicAtlas/standard-GEM/wiki/Use-case) of this standard see the [wiki pages of the `standard-GEM` repository](https://github.com/MetabolicAtlas/standard-GEM/wiki).
 
 ### Terminology
-To facilitate understading, the definitions used throughout this guide are copied below  [from the wiki](https://github.com/MetabolicAtlas/standard-GEM/wiki/Aims,-scope-and-terminology#terminology). For easier differentiation, we have associated colors to each of them.
+To facilitate understanding, the definitions used throughout this guide are copied below  [from the wiki](https://github.com/MetabolicAtlas/standard-GEM/wiki/Aims,-scope-and-terminology#terminology). For easier differentiation, we have associated colors to each of them.
 ```
 Based on the ISO guidelines, tweaked for easy understanding.
 🟥 Requirements: must, must not


### PR DESCRIPTION
The `.standard-GEM.md` guidelines have been updated based on feedback from Ulf Liebal, correcting a typo and improving the description of two fields: _url_ and _releases_.