### PR TITLE
chore: rename master to main, including Yeast-GEM refs

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -7,7 +7,7 @@
 
 
 #### Current feature/value/output:
-*How the reaction/metabolite/gene/simulation actually looks in the `master` branch. PLEASE DELETE THIS LINE.*
+*How the reaction/metabolite/gene/simulation actually looks in the `main` branch. PLEASE DELETE THIS LINE.*
 
 
 #### Reproducing these results:
@@ -18,7 +18,7 @@
 
 **I hereby confirm that I have:**
 - [ ] Tested my code with [all requirements](https://github.com/SysBioChalmers/yeast-GEM#required-software---user) for running the model
-- [ ] Done this analysis in the `master` branch of the repository
+- [ ] Done this analysis in the `main` branch of the repository
 - [ ] Checked that a similar issue does not exist already
 - [ ] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/yeast-GEM) about the issue
 

--- a/.standard-GEM.md
+++ b/.standard-GEM.md
@@ -22,7 +22,7 @@ With further updates to `standard-GEM`, one should paste over the new version of
 Repository creation
 -------------------
 - [ ] 🟨 Navigate to [standard-GEM](https://github.com/MetabolicAtlas/standard-GEM/) and click on the button `Use this template`  
-The `standard-GEM` template can be used to initiate a repository. This will copy the contents of the _master_ branch into the new repository, which can be either private or public.
+The `standard-GEM` template can be used to initiate a repository. This will copy the contents of the _main_ branch into the new repository, which can be either private or public.
 
 - [ ] 🟥 Pick a repository name  
 The name must be either a common name, KEGG organism, or taxonomy-derived short name, followed by the extension `-GEM` or `-GSMM`. The `-GEM` extension is preferred to ease pronunciation. The name can be prefixed by an abbreviation, eg `ec` (enzyme constrained), `sec` (with secretory pathways), `mito` (with mitochondrion pathways), `pro` (with protein structures).  
@@ -43,7 +43,7 @@ The URL can be the link to the publication/pre-print/website where the model is 
 Repository workflow
 -------------------
 - [ ] 🟥 Git branches  
-The GEM repository must have at least two branches: _master_ and _develop_.
+The GEM repository must have at least two branches: _main_ and _develop_.
 
 - [ ] 🟥 Releases  
 Releases must use the tag format `X.X.X` where X are numbers, according to [semantic versioning principles](https://semver.org/). The last field, also called “patch”, can also be used to indicate changes to the repository that do not actually change the GEM itself. The use of a `v` before the version number (`v1.0`) [is discouraged](https://semver.org/#is-v123-a-semantic-version). For more information about releases see the [documentation at GitHub](https://docs.github.com/en/github/administering-a-repository/managing-releases-in-a-repository).  
@@ -64,7 +64,7 @@ The repository must contain a `/.gitignore` file. This generic [.gitignore](http
 The repository must contain a `/.github` folder, in which the contributing guidelines, code of conduct, issue templates and pull request templates must be placed. Defaults are provided and they do not require any modification.
 
 - [ ] 🟥 `/.github/CONTRIBUTING.md`  
-This file is provided by the template, but it is empty. It must be filled in with the adequate contributing guideline instructions; a good example is https://github.com/SysBioChalmers/yeast-GEM/blob/master/.github/CONTRIBUTING.md.
+This file is provided by the template, but it is empty. It must be filled in with the adequate contributing guideline instructions; a good example is https://github.com/SysBioChalmers/yeast-GEM/blob/main/.github/CONTRIBUTING.md.
 
 - [ ] 🟥 `/code/README.md`  
 The repository must contain a `/code` folder. This folder must contain all the code used in generating the model. It must also include a `README.md` file that describes how the folder is organized.
@@ -74,12 +74,12 @@ The repository must contain a `/data` folder. This folder contains the data used
 
 - [ ] 🟥 `/model`  
 The repository must contain `/model` folder.  
-This folder must contain the model files, in multiple formats, according to the table below. As a general guideline, binary formats (`.mat`, `.xlsx`) must not exist on any other branches than _master_. The main reason for this is that binary files cannot be diff'ed, which means changes cannot be compared to previous versions, thus increasing the chance of errors. Moreover, with time, the size of the repository can create difficulties, and we cannot yet recommend storing these files with Git LFS, as it introducs complexity.  
+This folder must contain the model files, in multiple formats, according to the table below. As a general guideline, binary formats (`.mat`, `.xlsx`) must not exist on any other branches than _main_. The main reason for this is that binary files cannot be diff'ed, which means changes cannot be compared to previous versions, thus increasing the chance of errors. Moreover, with time, the size of the repository can create difficulties, and we cannot yet recommend storing these files with Git LFS, as it introducs complexity.  
 For more information on the `sbtab` file format, see [sbtab.net](https://sbtab.net).  
 All model files must be named the same as the repository, and with the appropriate extension.  
 Example: `yeast-GEM.mat`
 
-| Model file format | _master_ branch | _develop_ and other branches |
+| Model file format | _main_ branch | _develop_ and other branches |
 | ----------------- | --------------- | ---------------------------- |
 | JSON `.json`      | can             ||
 | Matlab `.mat`     | should          | must not                     |
@@ -106,4 +106,4 @@ The repository must contain this file, which is required for the version badge i
 The repository can be set up for continuous integration testing using memote with eg. Travis CI (`.travis.yml`), Jenkins (`Jenkinsfile`), GitHub Actions (under `.github/workflows`).
 
 - [ ] 🟨 _MEMOTE_ report  
-The repository could contain a [MEMOTE](https://www.nature.com/articles/s41587-020-0446-y) report on the _master_ branch, in `.html` format.
+The repository could contain a [MEMOTE](https://www.nature.com/articles/s41587-020-0446-y) report on the _main_ branch, in `.html` format.


### PR DESCRIPTION
### Main improvements in this PR:
This PR resolves #6 by renaming the use of `master` to `main`, including in links referring to `yeast-GEM`. The `master` branch was also renamed to `main` via GitHub's branch renaming UI.