### PR TITLE
fix: templates for GitHub Issues and Pull Requests

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,25 +1,23 @@
 ### Description of the issue:
-*Try to be as clear as possible: Is it something wrong/missing in the model? Is it a simulation issue? PLEASE DELETE THIS LINE.*
-
+<!-- Try to be as clear as possible: is it something wrong/missing in the model, or is it an improvement suggestion? -->
 
 #### Expected feature/value/output:
-*How the reaction/metabolite/gene/simulation result should look (cite literature if needed). PLEASE DELETE THIS LINE.*
-
+<!-- Please describe how the reaction/metabolite/gene/simulation result should like. It is helpful if literature can be referenced. -->
 
 #### Current feature/value/output:
-*How the reaction/metabolite/gene/simulation actually looks in the `main` branch. PLEASE DELETE THIS LINE.*
-
+<!-- How the reaction/metabolite/gene/simulation actually looks in the `main` branch. -->
 
 #### Reproducing these results:
-*Please attach any code used below (if it's python code replace the keyword "matlab" with "python". PLEASE DELETE THIS LINE.*
+<!-- Please attach any code used below (if it's python code replace the keyword "matlab" with "python". -->
+
 ```matlab
 
 ```
 
 **I hereby confirm that I have:**
+<!-- Note: replace [ ] with [X] to check the box. -->
+
 - [ ] Tested my code with [all requirements](https://github.com/SysBioChalmers/yeast-GEM#required-software---user) for running the model
 - [ ] Done this analysis in the `main` branch of the repository
 - [ ] Checked that a similar issue does not exist already
 - [ ] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/yeast-GEM) about the issue
-
-*Note: replace [ ] with [X] to check the box. PLEASE DELETE THIS LINE*

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -17,7 +17,7 @@
 **I hereby confirm that I have:**
 <!-- Note: replace [ ] with [X] to check the box. -->
 
-- [ ] Tested my code with [all requirements](https://github.com/SysBioChalmers/yeast-GEM#required-software---user) for running the model
+- [ ] Tested my code with to run the model
 - [ ] Done this analysis in the `main` branch of the repository
 - [ ] Checked that a similar issue does not exist already
-- [ ] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/yeast-GEM) about the issue
+- [ ] If needed, asked first in the Gitter chat room about the issue

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -17,7 +17,7 @@
 **I hereby confirm that I have:**
 <!-- Note: replace [ ] with [X] to check the box. -->
 
-- [ ] Tested my code with to run the model
-- [ ] Done this analysis in the `main` branch of the repository
-- [ ] Checked that a similar issue does not exist already
-- [ ] If needed, asked first in the Gitter chat room about the issue
+- [ ] tested my code with to run the model
+- [ ] done this analysis in the `main` branch of the repository
+- [ ] checked that a similar issue does not exist already
+- [ ] if needed, asked first in the Gitter chat room about the issue

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,5 +4,5 @@
 **I hereby confirm that I have:**
 <!-- Note: replace [ ] with [X] to check the box. -->
 
-- [ ] Tested my code on my own computer for running the model
-- [ ] Selected `devel` as a target branch
+- [ ] tested my code on my own computer for running the model
+- [ ] selected `devel` as a target branch

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,8 @@
 ### Main improvements in this PR:
-*Try to be as clear as possible: Is it fixing/adding something in the model? Is it an additional test/function/dataset? PLEASE DELETE THIS LINE.*
+<!-- Try to be as clear as possible: Is it fixing/adding something in the model? Is it an additional test/function/dataset? -->
 
 **I hereby confirm that I have:**
+<!-- Note: replace [ ] with [X] to check the box. -->
 
 - [ ] Tested my code on my own computer for running the model
 - [ ] Selected `devel` as a target branch
-
-*Note: replace [ ] with [X] to check the box. PLEASE DELETE THIS LINE*

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,4 +5,4 @@
 <!-- Note: replace [ ] with [X] to check the box. -->
 
 - [ ] tested my code on my own computer for running the model
-- [ ] selected `devel` as a target branch
+- [ ] selected `develop` as a target branch


### PR DESCRIPTION
### Main improvements in this PR:
This pull request resolves #29 by removing the unintended references to `yeast-GEM`, changes the way the instructions are included in the markdown, so that they don't need to be deleted, and fixes a broken reference to the development branch.

**I hereby confirm that I have:**
- [x] Selected `devel` as a target branch
