### PR TITLE
feat: testing with macaw

### DIFF
--- a/.github/workflows/commentMacaw.md
+++ b/.github/workflows/commentMacaw.md
@@ -1,4 +1,4 @@
-This PR has been [automatically tested with GH Actions](/../../actions/runs/{GH_ACTION_RUN}). Here is the output of the [MACAW](https://github.com/Devlin-Moyer/macaw) test:
+This PR has been [automatically tested with GH Actions](/actions/runs/{GH_ACTION_RUN}). Here is the output of the [MACAW](https://github.com/Devlin-Moyer/macaw) test:
 
 <pre>
 {TEST_RESULTS}

--- a/.github/workflows/commentMacaw.md
+++ b/.github/workflows/commentMacaw.md
@@ -1,0 +1,9 @@
+This PR has been [automatically tested with GH Actions](/../../actions/runs/{GH_ACTION_RUN}). Here is the output of the [MACAW](https://github.com/Devlin-Moyer/macaw) test:
+
+<pre>
+{TEST_RESULTS}
+</pre>
+
+This and a more detailed output from MACAW are also committed to `data/testResults/`.
+
+> _Note: In the case of multiple test runs, this post will be edited._

--- a/.github/workflows/macawTests.yml
+++ b/.github/workflows/macawTests.yml
@@ -1,0 +1,71 @@
+name: Run macaw tests
+
+on: [pull_request]
+
+jobs:
+  macaw-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Test checkout
+        run: ls -la && cd code && ls -la
+
+      - name: Set up Python 3
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install macaw
+        run: pip install git+https://github.com/Devlin-Moyer/macaw.git@main numpy==1.26.4
+
+      - name: Run macaw
+        id: macaw-run
+        run: |
+          TEST_RESULTS=$(python code/test/macawTests.py)
+          echo $TEST_RESULTS
+          PARSED_RESULTS="${TEST_RESULTS//$'\n'/'<br>'}"
+          PARSED_RESULTS="${PARSED_RESULTS//$'\r'/'<br>'}"
+          echo $PARSED_RESULTS
+          echo "results=$PARSED_RESULTS" >> $GITHUB_OUTPUT
+          printf "$TEST_RESULTS" > data/testResults/macaw_summary.md
+
+      - name: Mention PR# in README.md
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: sed -i -e "s/[[:digit:]]\{3,4\}\*\* (MACAW)/$PR_NUMBER\*\* (MACAW)/" data/testResults/README.md
+
+      - name: Update local branch before committing changes
+        env:
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }} 
+        run: |
+          git stash
+          git fetch
+          git checkout $BRANCH_NAME
+          if git stash list | grep -q 'stash@{'; then
+            git stash pop
+          fi
+
+      - name: Auto-commit results
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_user_name: memote-bot
+          commit_message: "chore: add macaw test result"
+          file_pattern: data/testResults/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.number }}
+
+      - name: Post comment
+        uses: NejcZdovc/comment-pr@v2
+        with:
+          file: "commentMacaw.md"
+          identifier: "GITHUB_COMMENT_MACAW"
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          TEST_RESULTS: ${{steps.macaw-run.outputs.results}}
+          GH_ACTION_RUN: ${{github.run_id}}
+          

--- a/code/test/macawTests.py
+++ b/code/test/macawTests.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+import cobra
+from macaw.main import dead_end_test, duplicate_test
+
+
+MODEL_DIR = Path("model")
+RESULTS_DIR = Path("data/testResults")
+RESULTS_FILE = RESULTS_DIR / "macaw_results.csv"
+
+
+def find_model_yaml():
+    model_files = sorted(
+        path
+        for pattern in ("*.yml", "*.yaml")
+        for path in MODEL_DIR.glob(pattern)
+        if path.is_file()
+    )
+
+    if not model_files:
+        raise FileNotFoundError(
+            f"No YAML model file found in {MODEL_DIR}. "
+            "Add exactly one .yml or .yaml model file before running MACAW."
+        )
+
+    if len(model_files) > 1:
+        files = ", ".join(str(path) for path in model_files)
+        raise RuntimeError(
+            f"Found multiple YAML model files in {MODEL_DIR}: {files}. "
+            "MACAW needs exactly one model file to test."
+        )
+
+    return model_files[0]
+
+
+def main():
+    model_path = find_model_yaml()
+    model = cobra.io.load_yaml_model(str(model_path))
+
+    dead_end_results, dead_end_edges = dead_end_test(model)
+    duplicate_results, duplicate_edges = duplicate_test(model)
+
+    output = dead_end_results.merge(duplicate_results)
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    output.to_csv(RESULTS_FILE, index=False)
+
+    print(f"Model tested: {model_path}")
+    print(f"Dead-end test rows: {len(dead_end_results)}")
+    print(f"Dead-end edge rows: {len(dead_end_edges)}")
+    print(f"Duplicate test rows: {len(duplicate_results)}")
+    print(f"Duplicate edge rows: {len(duplicate_edges)}")
+    print(f"Combined result rows written: {len(output)}")
+    print(f"Detailed results: {RESULTS_FILE}")
+
+
+if __name__ == "__main__":
+    main()

--- a/data/testResults/README.md
+++ b/data/testResults/README.md
@@ -1,0 +1,17 @@
+# Test results
+
+The file here contains results from the [MACAW](https://github.com/Devlin-Moyer/macaw) `dead_end_test` and `duplicate_test` tests.
+The results will be updated by any subsequent pull request. Summary results are shown as a comment in the corresponding pull request.
+
+### MACAW: `dead_end_test`
+Looks for metabolites in that can only be produced by all reactions they participate in or only consumed, then identifies all reactions that are prevented from sustaining steady-state fluxes because of each of these dead-end metabolites. The simplest case of a dead-end metabolite is one that only participates in a single reaction. Also flags all reversible reactions that can only carry fluxes in a single direction because one of their metabolites can either only be consumed or only be produced by all other reactions it participates in.
+
+### MACAW: `duplicate_test`
+Identifies sets of reactions that may be duplicates of each other because they:
+
+- Involve exactly the same metabolites with exactly the same stoichiometric coefficients (but potentially different associated genes).
+- Involve exactly the same metabolites, but go in different directions and/or some are reversible and some are not.
+- Involve exactly the same metabolites, but with different stoichiometric coefficients.
+- Represent the oxidation and/or reduction of the same metabolite, but use different electron acceptors/donors from the given list of pairs of oxidized and reduced forms of various electron carriers (e.g. NAD(H), NADP(H), FAD(H2), ubiquinone/ubiquinol, cytochromes).
+
+It is possible for a single reaction to fit in multiple of the above categories. There are sometimes cases where sets of reactions that fall into one of the above categories are completely legitimate representations of real biochemistry (e.g. separate irreversible reactions for importing vs exporting the same metabolite because two different transporters encoded by different genes are each responsible for transporting that metabolite in only one direction, enzymes that can use NAD(H) or NADP(H) interchangeably to catalyze the same redox reaction), but reactions that meet these criteria are generally worth close examination to ensure that they should actually all exist as separate reactions.


### PR DESCRIPTION
This PR implements testing with [MACAW](https://github.com/Devlin-Moyer/macaw), with documentation detailing the `dead_end_test` and `duplicate_test` methodologies and their significance, and thus resolves #36 .

### Main improvements in this PR:
Added a `testResults` folder that holds the MACAW results. The test suite posts the results as comments in the PR threads in addition to committing the results.

**I hereby confirm that I have:**

- [x] Tested my code on my own computer for running the model
- [x] Selected `develop` as a target branch
