### PR TITLE
fix: typos and enhance clarity in .standard-GEM.md

### DIFF
--- a/.standard-GEM.md
+++ b/.standard-GEM.md
@@ -4,11 +4,11 @@ standard-GEM 0.9
 For details about the [aims](https://github.com/MetabolicAtlas/standard-GEM/wiki/Aims,-scope-and-terminology#aims), [scope](https://github.com/MetabolicAtlas/standard-GEM/wiki/Aims,-scope-and-terminology#scope), and [use case](https://github.com/MetabolicAtlas/standard-GEM/wiki/Use-case) of this standard see the [wiki pages of the `standard-GEM` repository](https://github.com/MetabolicAtlas/standard-GEM/wiki).
 
 ### Terminology
-The definitions used throughout this guide are copied below [from the wiki](https://github.com/MetabolicAtlas/standard-GEM/wiki/Aims,-scope-and-terminology#terminology) to facilitate understanding. Colour labels are visual aids only; the words themselves define the requirement levelgitsdfdfsddsfds
+The definitions used throughout this guide are copied below [from the wiki](https://github.com/MetabolicAtlas/standard-GEM/wiki/Aims,-scope-and-terminology#terminology) to facilitate understanding. Colour labels are visual aids only; the words themselves define the requirement.
 ```
 Based on the ISO guidelines, tweaked for easy understanding.
 🟥 Requirements: must, must not. Mandatory for standard-GEM compliance.
-🟧 Recommendations: should, should not. Recommended
+🟧 Recommendations: should, should not.
 🟨 Possibility and capability: can. Optional or technically possible.
 ```
 
@@ -22,13 +22,13 @@ With further updates to `standard-GEM`, maintainers should paste over the new ve
 Repository creation
 -------------------
 - [ ] 🟨 Navigate to [standard-GEM](https://github.com/MetabolicAtlas/standard-GEM/) and click on the button `Use this template`  
-On GitHub, the `standard-GEM` template can be used to initiate a repository. This will copy the contents of the _main_ branch into the new repository, which can be either private or public. If the repository already exists, it sufficient copy this file and follow the follow the recommendations within it.
+On GitHub, the `standard-GEM` template can be used to initiate a repository. This will copy the contents of the _main_ branch into the new repository, which can be either private or public. If the repository already exists, it is sufficient to copy this file and follow the recommendations within it.
 
 - [ ] 🟥 Repository name  
 The name must be either a common name, KEGG organism, or taxonomy-derived short name, followed by the extension `-GEM` or `-GSMM`. The `-GEM` extension is preferred to ease pronunciation. An abbreviation can prefix the name, e.g., `ec` (enzyme constrained), `sec` (with secretory pathways), `mito` (with mitochondrion pathways), `pro` (with protein structures).  
 Example: `ecYeast-GEM`
 
-- [ ] 🟥 The namimg must be consistent.  
+- [ ] 🟥 The naming must be consistent.  
 The repository name must also be applied to the model itself, including names of model files.
 
 - [ ] 🟥 Pick a repository description  
@@ -73,7 +73,7 @@ The repository must contain a `/.github` folder, in which the contributing guide
 The template provides this file, but it is empty. It must be filled in with the adequate contributing guideline instructions; a good example is https://github.com/SysBioChalmers/yeast-GEM/blob/main/.github/CONTRIBUTING.md.
 
 - [ ] 🟨 `/.github/workflows`  
-The template can contain an optional folder with for running automated workflows. The template provides a predefined workflow that runs [MACAW](https://doi.org/10.1186/s13059-025-03533-6) on the YAML model file in each pull request, sharing the result in as a message in said pull request, and also committing the detailed result to the repository in the `/data/testResults` folder.
+The template can contain an optional folder for running automated workflows. The template provides a predefined workflow that runs [MACAW](https://doi.org/10.1186/s13059-025-03533-6) on the YAML model file in each pull request, sharing the result as a message in said pull request, and also committing the detailed result to the repository in the `/data/testResults` folder.
 
 - [ ] 🟥 `/code/README.md`  
 The repository must contain a `/code` folder. This folder must contain all the code used in generating the model. It must also include a `README.md` file that describes how the folder is organised.
@@ -82,9 +82,9 @@ The repository must contain a `/code` folder. This folder must contain all the c
 The repository can contain a `/code/test` folder. This folder must contain all the tests performed on the model.
 
 - [ ] 🟥 `/data/README.md`  
-The repository must contain a `/data` folder. This folder contains the data used in generating the model. It must also include a `README.md` file that describes how the folder is organized.
+The repository must contain a `/data` folder. This folder contains the data used in generating the model. It must also include a `README.md` file that describes how the folder is organised.
 
-- [ ] 🟨 `/data/testReults`  
+- [ ] 🟨 `/data/testResults`  
 The repository can contain a folder to store the results of tests.
 
 - [ ] 🟥 `/model`  
@@ -115,7 +115,7 @@ Additionally, the `/README.md` file should contain the [Zenodo](https://zenodo.o
 The `/README.md` can contain a contact badge, e.g., [Gitter](https://gitter.io). When setting up the Gitter chat room, the GitHub activity should be synced with Gitter in order to see the latest repository updates in the chat room. The default for this badge is provided in the file.
 
 - [x] 🟥 `/version.txt`  
-The repository must contain this file, which is required for the version badge in the `/README.md`. The value refers to the GEM, not of the `standard-GEM`. The value must be updated with each release.
+The repository must contain this file, which is required for the version badge in the `/README.md`. The value refers to the GEM, not to `standard-GEM`. The value must be updated with each release.
 
 - [ ] 🟨 Files for continuous integration testing  
 The repository can be set up for continuous integration testing using memote with, e.g., Jenkins (`Jenkinsfile`), and GitHub Actions (under `.github/workflows`).


### PR DESCRIPTION
### Main improvements in this PR:
This PR aims to correct typos and improve clarity immediately - it seems the previous release would have benefited from an better review.

**I hereby confirm that I have:**
<!-- Note: replace [ ] with [X] to check the box. -->

- [ ] tested my code on my own computer for running the model
- [x] selected `develop` as a target branch
